### PR TITLE
Update to support guzzle7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "issues": "https://github.com/cyber-duck/silverstripe-recaptcha"
     },
     "require": {
-        "guzzlehttp/guzzle": "~6"
+        "guzzlehttp/guzzle": "~6|~7"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION

SilverStripe 4.11 makes use of guzzle 7.

https://docs.silverstripe.org/en/4/changelogs/4.11.0/#guzzlehttp-guzzle

Being fixed to ~6 is keeping this module incompatible.



Opened issue on Cyber-Duck/SilverStripe-Recaptcha.


https://github.com/Cyber-Duck/SilverStripe-Recaptcha/issues/4